### PR TITLE
Shows examples on grammar show page, and can add example from page

### DIFF
--- a/app/controllers/examples_controller.rb
+++ b/app/controllers/examples_controller.rb
@@ -9,7 +9,7 @@ class ExamplesController < ApplicationController
   end
 
   def new
-    @example = Example.new
+    @example = Example.new(grammar_id: params[:grammar_id])
   end
 
   def edit

--- a/app/controllers/grammars_controller.rb
+++ b/app/controllers/grammars_controller.rb
@@ -4,6 +4,7 @@ class GrammarsController < ApplicationController
   # GET /grammars
   def index
     @grammars = Grammar.includes(:dialect)
+    @grammars = @grammars.where(dialect_id: params[:dialect_id]) if params[:dialect_id]
   end
 
   # GET /grammars/1

--- a/app/views/dialects/index.html.erb
+++ b/app/views/dialects/index.html.erb
@@ -17,6 +17,7 @@
         <td><%= dialect.name_en %></td>
         <td><%= dialect.name_jp %></td>
         <td><%= link_to 'Show', dialect %></td>
+        <td><%= link_to 'View Grammars', grammars_path(dialect_id: dialect.id) %></td>
         <td><%= link_to 'Edit', edit_dialect_path(dialect) %></td>
         <td><%= link_to 'Destroy', dialect, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/grammars/show.html.erb
+++ b/app/views/grammars/show.html.erb
@@ -15,5 +15,19 @@
   <%= @grammar.position %>
 </p>
 
+<p>
+  <strong>Examples:</strong>
+  <br>
+  <% @grammar.examples.each do |example| %>
+    <span><%= example.sentence1 %></span>
+    <span><%= example.sentence2 %></span>
+    <%= link_to "Edit", edit_example_path(example) %>
+    <br>
+  <% end %>
+</p>
+
+
+
+<%= link_to 'Add Example', new_example_path(grammar_id: @grammar.id) %> |
 <%= link_to 'Edit', edit_grammar_path(@grammar) %> |
 <%= link_to 'Back', grammars_path %>


### PR DESCRIPTION
This PR adds links to the examples from the grammar show page to make it easy to navigate.
Also allows you to view all grammars based on dialect.
Finally lets the user create an example directly from the grammar page that you want it to be associated from.

<img width="507" alt="Screen Shot 2021-01-03 at 5 24 25 PM" src="https://user-images.githubusercontent.com/4443635/103493883-cf43a380-4de8-11eb-9164-73a21bb8375b.png">
<img width="507" alt="Screen Shot 2021-01-03 at 5 24 25 PM" src="https://user-images.githubusercontent.com/4443635/103611027-3ee38c80-4ed6-11eb-83a8-ba8943ecdfc2.png">


