### PR TITLE
Add complete btn text

### DIFF
--- a/app/controllers/api/dialects_controller.rb
+++ b/app/controllers/api/dialects_controller.rb
@@ -9,6 +9,7 @@ module Api
           name_jp: dialect.name_jp, 
           start_btn_text: dialect.start_btn_text, 
           next_btn_text: dialect.next_btn_text, 
+          complete_btn_text: dialect.complete_btn_text, 
           grammars: dialect.grammars.map do |grammar|
              {
               id: grammar.id,

--- a/app/controllers/dialects_controller.rb
+++ b/app/controllers/dialects_controller.rb
@@ -69,6 +69,6 @@ class DialectsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def dialect_params
-      params.require(:dialect).permit(:name_en, :name_jp, :start_btn_text, :next_btn_text)
+      params.require(:dialect).permit(:name_en, :name_jp, :start_btn_text, :next_btn_text, :complete_btn_text)
     end
 end

--- a/app/views/dialects/_form.html.erb
+++ b/app/views/dialects/_form.html.erb
@@ -31,6 +31,11 @@
     <%= form.text_field :next_btn_text, placeholder: "次へ進む"  %>
   </div>
 
+  <div class="field">
+    <%= form.label :complete_btn_text %>
+    <%= form.text_field :complete_btn_text, placeholder: "できた"  %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/dialects/show.html.erb
+++ b/app/views/dialects/show.html.erb
@@ -20,5 +20,10 @@
   <%= @dialect.next_btn_text %>
 </p>
 
+<p>
+  <strong> Complete button text:</strong>
+  <%= @dialect.complete_btn_text %>
+</p>
+
 <%= link_to 'Edit', edit_dialect_path(@dialect) %> |
 <%= link_to 'Back', dialects_path %>

--- a/db/migrate/20210107013807_add_complete_btn_text_to_dialects.rb
+++ b/db/migrate/20210107013807_add_complete_btn_text_to_dialects.rb
@@ -1,0 +1,5 @@
+class AddCompleteBtnTextToDialects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :dialects, :complete_btn_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_06_035306) do
+ActiveRecord::Schema.define(version: 2021_01_07_013807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_035306) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "start_btn_text"
     t.string "next_btn_text"
+    t.string "complete_btn_text"
   end
 
   create_table "examples", force: :cascade do |t|


### PR DESCRIPTION
Add a column for complete_btn_text to dialects. Displays it and create/ edit it.

<img width="275" alt="Screen Shot 2021-01-06 at 5 51 59 PM" src="https://user-images.githubusercontent.com/60206746/103841203-e16f4d00-5047-11eb-9059-0ccb9897ecba.png">
<img width="254" alt="Screen Shot 2021-01-06 at 5 52 18 PM" src="https://user-images.githubusercontent.com/60206746/103841234-ee8c3c00-5047-11eb-8da5-e6b1e85d53ee.png">
<img width="211" alt="Screen Shot 2021-01-06 at 5 52 39 PM" src="https://user-images.githubusercontent.com/60206746/103841253-f946d100-5047-11eb-98fc-36d97385e170.png">
