### PR TITLE
display dialect name in grammar show page

### DIFF
--- a/app/views/grammars/show.html.erb
+++ b/app/views/grammars/show.html.erb
@@ -1,6 +1,11 @@
 <p id="notice"><%= notice %></p>
 
 <p>
+  <strong>Dialect:</strong>
+  <%= @grammar.dialect.name_en %>
+</p>
+
+<p>
   <strong>Dialect id:</strong>
   <%= @grammar.dialect_id %>
 </p>


### PR DESCRIPTION
Shows dialect name in grammar detail page.

Before: 
<img width="337" alt="Screen Shot 2021-01-07 at 4 15 18 PM" src="https://user-images.githubusercontent.com/60206746/103959545-ca426500-5104-11eb-9c10-8d5461abb04d.png">

After:
<img width="332" alt="Screen Shot 2021-01-07 at 4 15 31 PM" src="https://user-images.githubusercontent.com/60206746/103959522-beef3980-5104-11eb-8c27-d03b3dcfe944.png">
