### PR TITLE
add number of example in grammar index page

### DIFF
--- a/app/views/grammars/index.html.erb
+++ b/app/views/grammars/index.html.erb
@@ -21,7 +21,7 @@
         <td><%= grammar.label %></td>
         <td><%= grammar.description %></td>
         <td><%= grammar.position %></td>
-        <td><%= grammar.examples.length %></td>
+        <td><%= grammar.examples.size %></td>
         <td><%= link_to 'Show', grammar %></td>
         <td><%= link_to 'Edit', edit_grammar_path(grammar) %></td>
         <td><%= link_to 'Destroy', grammar, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/grammars/index.html.erb
+++ b/app/views/grammars/index.html.erb
@@ -9,6 +9,7 @@
       <th>Label</th>
       <th>Description</th>
       <th>Position</th>
+      <th>Examples数</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -20,6 +21,7 @@
         <td><%= grammar.label %></td>
         <td><%= grammar.description %></td>
         <td><%= grammar.position %></td>
+        <td><%= grammar.examples.length %></td>
         <td><%= link_to 'Show', grammar %></td>
         <td><%= link_to 'Edit', edit_grammar_path(grammar) %></td>
         <td><%= link_to 'Destroy', grammar, method: :delete, data: { confirm: 'Are you sure?' } %></td>


### PR DESCRIPTION
Added number of example in grammar index page.

![Screen Shot 2021-01-11 at 3 04 38 PM](https://user-images.githubusercontent.com/60206746/104248431-54990a80-541e-11eb-8c84-4edf4fafe5c8.png)
