### PR TITLE
Use enum for area column

### DIFF
--- a/app/models/dialect.rb
+++ b/app/models/dialect.rb
@@ -2,4 +2,6 @@ class Dialect < ApplicationRecord
   has_many :grammars
   has_many :place_infos
   has_one_attached :default_image
+
+  enum status: [:hokkaido, :tohoku, :kanto, :chubu, :kinki, :chugoku, :shikoku, :kyushu, :not_set]
 end

--- a/app/models/dialect.rb
+++ b/app/models/dialect.rb
@@ -3,5 +3,5 @@ class Dialect < ApplicationRecord
   has_many :place_infos
   has_one_attached :default_image
 
-  enum status: [:hokkaido, :tohoku, :kanto, :chubu, :kinki, :chugoku, :shikoku, :kyushu, :not_set]
+  enum areas: { Hokkaido: 0, Tohoku: 1, Kanto: 2, Chubu:3, Kinki: 4, Chugoku: 5,Shikoku: 6, Kyushu: 7, Not_set: 8 }
 end

--- a/app/views/dialects/_form.html.erb
+++ b/app/views/dialects/_form.html.erb
@@ -23,7 +23,7 @@
 
   <div class="field">
     <%= form.label :area %>
-    <%= form.select :area, {"Hokkaido": "Hokkaido", "Tohoku": "Tohoku", "Kanto": "Kanto", "Chubu": "Chubu","Kinki": "Kinki", "Chugoku": "Chugoku", "Shikoku": "Shikoku", "Kyushu": "Kyushu"}, { include_blank: "Select area"}, {required: true} %>
+    <%= form.select :area, {"Hokkaido": 0, "Tohoku": 1, "Kanto": 2, "Chubu": 3,"Kinki": 4, "Chugoku": 5, "Shikoku": 6, "Kyushu": 7}, { include_blank: "Select area"}, {required: true} %>
   </div>
   
   <div class="field">

--- a/app/views/dialects/index.html.erb
+++ b/app/views/dialects/index.html.erb
@@ -17,7 +17,8 @@
       <tr>
         <td><%= dialect.name_en %></td>
         <td><%= dialect.name_jp %></td>
-        <td><%= dialect.area %></td>
+
+        <td><%= Dialect.areas.key(dialect.area) %></td>
         <td><%= link_to 'Show', dialect %></td>
         <td><%= link_to 'View Grammars', grammars_path(dialect_id: dialect.id) %></td>
         <td><%= link_to 'View Places', place_infos_path(dialect_id: dialect.id) %></td>

--- a/app/views/dialects/show.html.erb
+++ b/app/views/dialects/show.html.erb
@@ -12,7 +12,7 @@
 
 <p>
   <strong>Area:</strong>
-  <%= @dialect.area %>
+  <%= Dialect.areas.key(@dialect.area) %>
 </p>
 
 <p><strong>Default picture:</strong></p>

--- a/db/migrate/20211227010238_change_dialect_area.rb
+++ b/db/migrate/20211227010238_change_dialect_area.rb
@@ -1,0 +1,5 @@
+class ChangeDialectArea < ActiveRecord::Migration[6.0]
+  def change
+    change_column :dialects, :area, 'integer USING CAST(area AS integer)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_18_231634) do
+ActiveRecord::Schema.define(version: 2021_12_27_010238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2021_12_18_231634) do
     t.string "next_btn_text"
     t.string "complete_btn_text"
     t.text "description"
-    t.string "area"
+    t.integer "area"
   end
 
   create_table "examples", force: :cascade do |t|


### PR DESCRIPTION
Changed area type to enum to sort dialects by area from north to south.

https://user-images.githubusercontent.com/60206746/147508847-b0d127f5-6872-4017-82cb-8424d06259df.mov


