### PR TITLE
Limit the number of images for place info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,5 @@ gem "image_processing"
 
 gem "graphql"
 gem 'graphiql-rails', group: :development
+
+gem 'active_storage_validations', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (0.9.7)
+      activejob (>= 5.2.0)
+      activemodel (>= 5.2.0)
+      activestorage (>= 5.2.0)
+      activesupport (>= 5.2.0)
     activejob (6.1.4.4)
       activesupport (= 6.1.4.4)
       globalid (>= 0.3.6)
@@ -224,6 +229,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_storage_validations (~> 0.8)
   aws-sdk-s3
   bootsnap (>= 1.4.2)
   byebug

--- a/app/models/place_info.rb
+++ b/app/models/place_info.rb
@@ -1,6 +1,7 @@
 class PlaceInfo < ApplicationRecord
   belongs_to :dialect
-  has_many_attached :images
+  has_many_attached :images 
 
-  validates :description, :presence => true, :length => { maximum: 280 } 
+  validates :description, :presence => true, :length => { maximum: 280 }
+  validates :images, attached_file_number: { maximum: 3 }
 end

--- a/app/validators/attached_file_number_validator.rb
+++ b/app/validators/attached_file_number_validator.rb
@@ -1,0 +1,11 @@
+class AttachedFileNumberValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return true unless value.attached?
+
+    file_number = value.size
+
+    if(limit = options[:maximum]).present? && file_number > limit
+      record.errors.add(attribute, :too_many_files, count: limit)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,6 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  errors:
+    messages:
+      too_many_files: size should be %{count} or less


### PR DESCRIPTION
## Description ✏️ 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue) -->

The user should be able to upload up to 3 images when creating/ editing place info.
## Type of change ⭐ 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Solution 💡 
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--
- [ ] Test A
- [ ] Test B
-->

Added `active_storage_validations` gem. When the user tries to upload more than 3 images, it shows error messages.

<img width="537" alt="Screen Shot 2022-04-17 at 10 49 40 PM" src="https://user-images.githubusercontent.com/60206746/163717431-25db083e-2aef-4962-bc31-efa422881c7a.png">


<!-- Add images if available -->
## Notes 📔

## Ticket 🎫 
