### PR TITLE
[Card #40] Grammar field in new quiz page

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class QuizzesController < ApplicationController
   before_action :set_quiz, only: [:show, :edit, :update, :destroy]
 
@@ -5,7 +7,7 @@ class QuizzesController < ApplicationController
     @quizzes = Quiz.includes(grammar: :dialect).order("dialects.name_en")
     if params[:grammar_id]
       @grammar = Grammar.find(params[:grammar_id])
-      @quizzes = @grammars.where(grammar: @grammar) 
+      @quizzes = @grammars.where(grammar: @grammar)
     end
   end
 
@@ -14,13 +16,25 @@ class QuizzesController < ApplicationController
 
   def new
     @quiz = Quiz.new(grammar_id: params[:grammar_id])
+    @dialects = Dialect.order(:name_en)
+
+    return unless params[:dialect_id].present?
+
+    @grammars =
+      Grammar.where(
+        dialect_id: params[:dialect_id]
+      ).order(:description)
   end
 
   def edit
   end
 
-  def create 
+  def create
     @quiz = Quiz.new(quiz_params)
+
+    if params[:quiz][:dialect_id] && quiz_params[:grammar_id].nil?
+      return redirect_to new_quiz_path(dialect_id: params[:quiz][:dialect_id])
+    end
 
     respond_to do |format|
       if @quiz.save
@@ -48,17 +62,18 @@ class QuizzesController < ApplicationController
   def destroy
     @quiz.destroy
     respond_to do |format|
-      format.html { redirect_back fallback_location: root_path, notice: 'Quiz was successfully destroyed.'}
+      format.html { redirect_back fallback_location: root_path, notice: 'Quiz was successfully destroyed.' }
       format.json { head :no_content }
     end
   end
 
   private
-    def set_quiz
-      @quiz = Quiz.find(params[:id])
-    end
 
-    def quiz_params
-      params.require(:quiz).permit(:tokyo, :answer, :grammar_id)
-    end
+  def set_quiz
+    @quiz = Quiz.find(params[:id])
+  end
+
+  def quiz_params
+    params.require(:quiz).permit(:tokyo, :answer, :grammar_id)
+  end
 end

--- a/app/views/quizzes/_form.html.erb
+++ b/app/views/quizzes/_form.html.erb
@@ -11,7 +11,19 @@
     </div>
   <% end %>
 
-  <%= form.hidden_field :grammar_id %>
+  <% if quiz.grammar_id.nil? %>
+    <div class="field">
+      <%= form.label :dialect_id %>
+      <%= form.collection_select :dialect_id, @dialects, :id, :name_en, {include_blank: 'None', selected: params[:dialect_id]}, {onChange: 'this.form.requestSubmit()', disabled: params[:dialect_id].present? } %>
+
+      <% if @grammars.present? %>
+        <%= form.label :grammar_id %>
+        <%= form.select :grammar_id, @grammars.pluck(:description, :id) %>
+      <% end %>
+    </div>
+  <% else %>
+    <%= form.hidden_field :grammar_id, value: quiz.grammar_id %>
+  <% end %>
 
   <div class="field">
     <%= form.label :tokyo %>
@@ -25,5 +37,11 @@
 
   <div class="actions">
     <%= form.submit %>
+  </div>
+
+  <div>
+    <button>
+      <%= link_to 'Back', quizzes_path %>
+    </button>
   </div>
 <% end %>

--- a/spec/controllers/quiz_controller_spec.rb
+++ b/spec/controllers/quiz_controller_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe QuizzesController, type: :controller do
+  describe '#create' do
+    let(:grammar) do
+      Grammar.create!(
+        description: 'test description',
+        position: 1,
+        dialect_id: 4,
+        label: 'test',
+        commonness: 3
+      )
+    end
+
+    context 'with valid params' do
+      let(:valid_params) do
+        {
+          tokyo: 'test tokyo',
+          answer: 'test answer',
+          grammar_id: grammar.id
+        }
+      end
+
+      it 'saves quiz properly' do
+        expect { Quiz.create!(valid_params) }.to change(Quiz, :count).by(1)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_params1) do
+        {
+          tokyo: nil,
+          answer: 'test answer',
+          grammar_id: grammar.id
+        }
+      end
+      let(:invalid_params2) do
+        {
+          tokyo: 'test tokyo',
+          answer: nil,
+          grammar_id: grammar.id
+        }
+      end
+      let(:invalid_params3) do
+        {
+          tokyo: 'test tokyo',
+          answer: 'test answer',
+          grammar_id: nil
+        }
+      end
+      let(:invalid_params4) do
+        {
+          tokyo: nil,
+          answer: nil,
+          grammar_id: nil
+        }
+      end
+
+      it 'raises ActiveRecord::RecordInvalid error' do
+        expect { Quiz.create!(invalid_params1) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it 'raises ActiveRecord::RecordInvalid error' do
+        expect { Quiz.create!(invalid_params2) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it 'raises ActiveRecord::RecordInvalid error' do
+        expect { Quiz.create!(invalid_params3) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it 'raises ActiveRecord::RecordInvalid error' do
+        expect { Quiz.create!(invalid_params4) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description ✏️ 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue) -->
We need to add a field to select grammar when adding a new quiz.
## Type of change ⭐ 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Solution 💡 
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Added new fields for dialect and grammar in new quiz page.

Go to http://localhost:3000/quizzes/new and select dialect and grammar, then create a quiz :)
<!--
- [ ] Test A
- [ ] Test B
-->
<!-- Add images if available -->
## Notes 📔

## Ticket 🎫 
[Card #40](https://trello.com/c/J3jRm0dC)