### PR TITLE
[Card 50] Show only grammars that has examples

### DIFF
--- a/app/controllers/api/grammars_controller.rb
+++ b/app/controllers/api/grammars_controller.rb
@@ -3,8 +3,13 @@
 module Api
   class GrammarsController < ApplicationController
     def index
+      grammars_with_examples =
+        Grammar.order(:position)
+               .includes([[examples: :audio_clip_attachment], :quizzes])
+               .where.not(examples: { id: nil }).distinct
+
       grammars =
-        Grammar.order(:position).includes([[examples: :audio_clip_attachment], :quizzes]).map do |grammar|
+        grammars_with_examples.map do |grammar|
           {
             id: grammar.id,
             dialect_id: grammar.dialect_id,


### PR DESCRIPTION
## Description ✏️ 
We need to show only grammars that has examples instead of showing all grammars.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue) -->

## Type of change ⭐ 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Solution 💡 
Filtered out grammars without examples.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--
- [ ] Test A
- [ ] Test B
-->
<!-- Add images if available -->
## Notes 📔

## Ticket 🎫 
[Card 50](https://trello.com/c/AnyY4NNL)